### PR TITLE
removing id/slug swap

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -14,6 +14,5 @@ const { createNodeFactory } = createNodeHelpers({
  */
 export const Node = (type, node) =>
   createNodeFactory(type, node => {
-    node.id = node.slug
     return node
   })(node)


### PR DESCRIPTION
Swapping the `node.id`for the `node.slug` was blocking querying shared slugs across different languages. The new plugin update exposing locales in the root of the graphql query also dissalows us the ability to filter by local. By removing this line of code, users can filter by local for any content, including similar slugs across languages. This also removes the need to specify locales in the config file.