### PR TITLE
fix: handle undefined case in read_key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-cosmicjs",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -8,7 +8,7 @@ module.exports = async ({ apiURL, bucketSlug, objectType, apiAccess }) => {
   // Define API endpoint.
   let apiEndpoint = `${apiURL}/${bucketSlug}/objects?type=${objectType}`
 
-  if (apiAccess.hasOwnProperty('read_key') && apiAccess.read_key.length !== 0) {
+  if (apiAccess && apiAccess.read_key) {
     apiEndpoint = apiEndpoint + `&read_key=${apiAccess.read_key}`
   }
   // Make API request.


### PR DESCRIPTION
This fixes an issue where if options are passed like so:

```js
    {
      resolve: 'gatsby-source-cosmicjs',
      options: {
        bucketSlug: process.env.COSMIC_BUCKET || `gatsby-pro`,
        objectTypes: ['posts','settings'],
        apiAccess: {
          read_key: process.env.COSMIC_READ_KEY
        }
      }
    },
```

where process.env.COSMIC_READ_KEY is undefined, the value will still be passed when really we want to check for a "truthy" value.