### PR TITLE
Slug with hyphens causing GraphQL issues

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -3,12 +3,10 @@ const fetchData = require('./fetch')
 const { processObject } = require('./normalize')
 
 const createNodeHelper = (item, { createContentDigest, createNode }) => {
-  const typeSlug = _.capitalize(_.replace(item.type_slug, new RegExp("-","g"), ''))
-  const node = processObject(
-    typeSlug,
-    item,
-    createContentDigest
+  const typeSlug = _.capitalize(
+    _.replace(item.type_slug, new RegExp('-', 'g'), '')
   )
+  const node = processObject(typeSlug, item, createContentDigest)
   createNode(node)
 }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,10 +1,11 @@
-const capitalize = require('lodash/capitalize')
+const _ = require('lodash')
 const fetchData = require('./fetch')
 const { processObject } = require('./normalize')
 
 const createNodeHelper = (item, { createContentDigest, createNode }) => {
+  const typeSlug = _.capitalize(_.replace(item.type_slug, new RegExp("-","g"), ''))
   const node = processObject(
-    capitalize(item.type_slug),
+    typeSlug,
     item,
     createContentDigest
   )
@@ -70,7 +71,7 @@ exports.sourceNodes = async (
   const data = await Promise.all(promises)
 
   // Create nodes.
-  objectTypes.forEach((objectType, i) => {
+  objectTypes.forEach((_, i) => {
     var items = data[i]
     items.forEach(item => {
       createNodeHelper(item, helperObject)


### PR DESCRIPTION
ObjectType slugs with hyphens were causing some GraphQL issues. We fix it by removing hyphens from slug and then passing it to Gatsby GraphQL Node creation process.

#### Example
if ObjectType is `example-posts` then scheme generated will be `AllCosmicjsExampleposts` 