### PR TITLE
Implement structured reporting support

### DIFF
--- a/src/errorMap.js
+++ b/src/errorMap.js
@@ -1,0 +1,37 @@
+const pluginPrefix = 'gatsby-source-cosmicjs'
+
+function prefixId(id) {
+  return `${pluginPrefix}_${id}`
+}
+
+const ReporterLevel = {
+  Error = 'ERROR',
+}
+
+const ReporterCategory = {
+  // Error caused by user (typically, site misconfiguration)
+  User = 'USER',
+  // Error caused by Sanity plugin ("third party" relative to Gatsby Cloud)
+  ThirdParty = 'THIRD_PARTY',
+  // Error caused by Gatsby process
+  System = 'SYSTEM',
+}
+
+const CODES = {
+  MissingBucketSlug: '10000',
+}
+
+const ERROR_MAP = {
+  [CODES.MissingBucketSlug]: {
+    text: (context) => context.sourceMessage,
+    level: ReporterLevel.Error,
+    category: ReporterCategory.User,
+  },
+}
+
+module.exports = {
+    CODES,
+    ERROR_MAP,
+    pluginPrefix,
+    prefixId
+}

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,9 +1,16 @@
 const fetchData = require('./fetch')
 const { createNodeHelper } = require('./utils')
 const { createGatsbyImageResolver } = require('./gatsby-image-resolver')
+const { ERROR_MAP, CODES, prefixId } = require('./errorMap')
+
+exports.onPreInit = async ( { reporter }, {}) => {
+  if (reporter.setErrorMap) {
+    reporter.setErrorMap(ERROR_MAP)
+  }
+}
 
 exports.sourceNodes = async (
-  { actions, webhookBody, createContentDigest, getNode },
+  { actions, webhookBody, createContentDigest, getNode, reporter },
   {
     apiURL = 'https://api.cosmicjs.com/v1',
     bucketSlug = '',
@@ -14,6 +21,14 @@ exports.sourceNodes = async (
   }
 ) => {
   const { createNode, deleteNode } = actions
+
+  reporter.panic(
+    {
+      id: prefixId(CODES.MissingBucketSlug),
+      context: {sourceMessage: err.stack},
+    },
+    err.stack,
+  )
 
   const helperObject = {
     createContentDigest,


### PR DESCRIPTION
> I am a GatsbyJS employee (on the Cloud side of things) - we are currently working to improve categorization of errors that users may encounter when building their site by utilizing the Structured Reporting API. This will help us improve user experience for Gatsby+CosmicJS sites built through Gatsby Cloud.

# Description

GatsbyJS' `Reporter` supports the concept of "structured reporting", where a plugin can report custom codes to Gatsby Cloud about an event that just occurred. Specifically, we are looking into categorizing all errors through this API as either `SYSTEM`, `THIRD_PARTY` or `USER` errors.

Normally, this task would be to replace anywhere there is a call to `reporter.panic` with a backwards-compatible call. However, I noticed this plugin didn't have any panic calls, so I added one in the event that a user did not provide the `bucketSlug`. I'm sure there are other cases, but I'll need some help identifying where else you think errors should be reported. Thanks in advance!
