### PR TITLE
Add configuration option for number of objects fetched per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ plugins: [
       apiAccess: {
         read_key: ``, // Get this value in Bucket > Settings
       },
-      localMedia: true // Download media locally for gatsby image (optional)
+      localMedia: true, // Download media locally for gatsby image (optional)
+      limit: 1000, // The number of Objects to fetch on each request (optional)
     }
   },
 ]

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -7,6 +7,7 @@ module.exports = async ({
   bucketSlug,
   objectType,
   apiAccess,
+  limit,
   preview,
 }) => {
   const timeLabel = `Fetch Cosmic JS data for (${objectType})`
@@ -14,7 +15,6 @@ module.exports = async ({
     headers: { 'Accept-Encoding': 'gzip, deflate' },
   }
   let objects = []
-  const limit = 100
   let skip = 0
   console.time(timeLabel)
   console.log(`Starting to fetch data from Cosmic JS (${objectType})`)

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -14,7 +14,7 @@ module.exports = async ({
     headers: { 'Accept-Encoding': 'gzip, deflate' },
   }
   let objects = []
-  const limit = 1000
+  const limit = 100
   let skip = 0
   console.time(timeLabel)
   console.log(`Starting to fetch data from Cosmic JS (${objectType})`)

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -9,6 +9,7 @@ exports.sourceNodes = async (
     bucketSlug = '',
     objectTypes = [],
     apiAccess = {},
+    limit = 1000,
     preview = false,
     localMedia = false,
   }
@@ -57,6 +58,7 @@ exports.sourceNodes = async (
       bucketSlug,
       objectType,
       apiAccess,
+      limit,
       preview,
     })
   )


### PR DESCRIPTION
For complex content models, the current default value of `1000` objects per request can cause a request to exceed the API limit of 6MB. This lets the user configure a lower number in `gatsby-config.js` to help reduce the response payload.

https://docs.cosmicjs.com/graphql-api/request-limits.html