### PR TITLE
fix: Fix touchNode call to work with Gatsby 5

### DIFF
--- a/src/gatsby-image-resolver.js
+++ b/src/gatsby-image-resolver.js
@@ -15,7 +15,6 @@ exports.createGatsbyImageResolver = (
           type: `File`,
           async resolve(source, _args, _context, _info) {
             if (source.url) {
-              let fileNodeID
               let fileNode
               const checksum = md5(source.value)
 
@@ -29,15 +28,16 @@ exports.createGatsbyImageResolver = (
 
                 // check if node still exists in cache
                 if (fileNode) {
-                  fileNodeID = cacheMediaData.fileNodeID
                   touchNode({
-                    nodeId: fileNodeID,
+                    ...fileNode,
+                    // Keep nodeId to make it backward compatible
+                    nodeId: fileNode.id,
                   })
                 }
               }
 
               // If we don't have cached data, download the file
-              if (!fileNodeID) {
+              if (!fileNode) {
                 try {
                   // Get the filenode
                   fileNode = await createRemoteFileNode({
@@ -50,7 +50,7 @@ exports.createGatsbyImageResolver = (
                   })
 
                   if (fileNode) {
-                    fileNodeID = fileNode.id
+                    const fileNodeID = fileNode.id
 
                     await cache.set(mediaDataCacheKey, {
                       fileNodeID,


### PR DESCRIPTION
In Gatsby 5, the signature of `touchNode` has changed ([0927cb0](https://github.com/gatsbyjs/gatsby/commit/0927cb007d0774bed8cf5ead3130ff6b7c3393b7)). 
It now expects whole node object instead of just a `nodeId` field.

This fix calls the `touchNode` function with full `fileNode` value and adds `nodeId` field for backwards compatibility.